### PR TITLE
Tagging support

### DIFF
--- a/Public/static/js/admin/createPost.js
+++ b/Public/static/js/admin/createPost.js
@@ -25,6 +25,23 @@ $(function() {
   $("#inputTags").select2({
     tags: true,
     tokenSeparators: [','],
+    ajax: {
+        url: "/blog/api/tags/",
+        processResults: function (data) {
+            var dataToReturn = [];
+
+            for (var i=0; i < data.length; i++) {
+                var tagToTransform = data[i];
+                var newTag = {id: tagToTransform["name"], text: tagToTransform["name"]};
+                dataToReturn.push(newTag);
+            }
+            return {
+                results: dataToReturn
+            }
+        },
+        delay: 250,
+        cache: true
+    },
     data: data,
     placeholder: "Select Tags for the Blog Post",
   });

--- a/Public/static/js/admin/createPost.js
+++ b/Public/static/js/admin/createPost.js
@@ -19,6 +19,17 @@ $('#inputTitle').on('input',function(e){
   }
 });
 
+var data = [{ id: 0, text: 'enhancement' }, { id: 1, text: 'bug' }, { id: 2, text: 'duplicate' }, { id: 3, text: 'invalid' }, { id: 4, text: 'wontfix' }];
+
+$(function() {
+  $("#inputTags").select2({
+    tags: true,
+    tokenSeparators: [',', ' '],
+    //data: data,
+    placeholder: "Select Tags for the Blog Post",
+  });
+});
+
 $('#cancel-edit-button').click(function(){
     return confirm('Are you sure you want to cancel? You will lose any unsaved work');
 });

--- a/Public/static/js/admin/createPost.js
+++ b/Public/static/js/admin/createPost.js
@@ -19,31 +19,22 @@ $('#inputTitle').on('input',function(e){
   }
 });
 
-var data = [{ id: 'enhancement', text: 'enhancement' }, { id: 'bug', text: 'bug' }, { id: 'duplicate', text: 'duplicate' }, { id: 'invalid', text: 'invalid' }];
-
-$(function() {
-  $("#inputTags").select2({
+$.ajax({
+  url: "/blog/api/tags/",
+  type: 'GET',
+  contentType: 'application/json; charset=utf-8'
+}).then(function (response) {
+    var dataToReturn = [];
+    for (var i=0; i < response.length; i++) {
+        var tagToTransform = response[i];
+        var newTag = {id: tagToTransform["name"], text: tagToTransform["name"]};
+        dataToReturn.push(newTag);
+    }
+    $("#inputTags").select2({
+    placeholder: "Select Tags for the Blog Post",
     tags: true,
     tokenSeparators: [','],
-    ajax: {
-        url: "/blog/api/tags/",
-        processResults: function (data) {
-            var dataToReturn = [];
-
-            for (var i=0; i < data.length; i++) {
-                var tagToTransform = data[i];
-                var newTag = {id: tagToTransform["name"], text: tagToTransform["name"]};
-                dataToReturn.push(newTag);
-            }
-            return {
-                results: dataToReturn
-            }
-        },
-        delay: 250,
-        cache: true
-    },
-    data: data,
-    placeholder: "Select Tags for the Blog Post",
+    data: dataToReturn
   });
 });
 

--- a/Public/static/js/admin/createPost.js
+++ b/Public/static/js/admin/createPost.js
@@ -19,13 +19,13 @@ $('#inputTitle').on('input',function(e){
   }
 });
 
-var data = [{ id: 0, text: 'enhancement' }, { id: 1, text: 'bug' }, { id: 2, text: 'duplicate' }, { id: 3, text: 'invalid' }, { id: 4, text: 'wontfix' }];
+var data = [{ id: 'enhancement', text: 'enhancement' }, { id: 'bug', text: 'bug' }, { id: 'duplicate', text: 'duplicate' }, { id: 'invalid', text: 'invalid' }];
 
 $(function() {
   $("#inputTags").select2({
     tags: true,
-    tokenSeparators: [',', ' '],
-    //data: data,
+    tokenSeparators: [','],
+    data: data,
     placeholder: "Select Tags for the Blog Post",
   });
 });

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The `herokuVersion` branch contains a PostgreSQL provider but if you are using t
 For the time being, I will keep the releases under a 0 version - so expect breaking changes for a while as the codebase evolves. If there is demand to stabilise the site (i.e. lots of people are using it for an actual blog rather than just reference for their own blogs) then I'll bump up the priority of this accordingly. For the moment though, I am expecting some significant breaking changes in the [main engine](https://github.com/brokenhandsio/SteamPress) so expect those to happen before any stabilisation occurs. Other features that are on the roadmap specific to this site are:
 
 * Javascript validation of form fields before form submission, as well as realtime password validation.
-* Improving the way tags are applied to blog posts (some javascript to make it easier to add existing tags and not see it as a string)
 * Social media share buttons in the post temaplate
 * Twitter card support for adding tweets
 * AMP support for posts (in conjuction with new endpoints for all pages for AMP)

--- a/Resources/Views/blog/admin/createPost.leaf
+++ b/Resources/Views/blog/admin/createPost.leaf
@@ -65,11 +65,10 @@
             <div class="form-group" id="create-post-tags-group">
                 <label class="form-control-label" for="inputTags">Tags</label>
                 <select class="form-control" id="inputTags" name="inputTags" placeholder="Tags" multiple="multiple">
-                  <!-- <option selected="selected">orange</option>
-                  <option>white</option>
-                  <option selected="selected">purple</option> -->
+                  #loop(tagsSupplied, "tag") {
+                    <option value="#(tag)" selected="selected">#(tag)</option>
+                  }
                 </select>
-                <!-- <input type="text" class="form-control" id="inputTags" name="inputTags" placeholder="Tags" value="#(tagsSupplied)"> -->
                 <small id="tagHelpBlock" class="form-text text-muted">
                     Tags can be added to your posts as comma-separated entries.
                 </small>

--- a/Resources/Views/blog/admin/createPost.leaf
+++ b/Resources/Views/blog/admin/createPost.leaf
@@ -64,7 +64,12 @@
 
             <div class="form-group" id="create-post-tags-group">
                 <label class="form-control-label" for="inputTags">Tags</label>
-                <input type="text" class="form-control" id="inputTags" name="inputTags" placeholder="Tags" value="#(tagsSupplied)">
+                <select class="form-control" id="inputTags" name="inputTags" placeholder="Tags" multiple="multiple">
+                  <option selected="selected">orange</option>
+                  <option>white</option>
+                  <option selected="selected">purple</option>
+                </select>
+                <!-- <input type="text" class="form-control" id="inputTags" name="inputTags" placeholder="Tags" value="#(tagsSupplied)"> -->
                 <small id="tagHelpBlock" class="form-text text-muted">
                     Tags can be added to your posts as space-separated words.
                 </small>

--- a/Resources/Views/blog/admin/createPost.leaf
+++ b/Resources/Views/blog/admin/createPost.leaf
@@ -2,10 +2,13 @@
 
 #export("head") {
 <title>#if(editing) { Edit } ##else() { Create } Blog Post | Blog Admin | SteamPress</title>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" integrity="sha256-xJOZHfpxLR/uhh1BwYFS5fhmOAdIRQaiOul5F/b7v3s= sha384-HIipfSYbpCkh5/1V87AWAeR5SUrNiewznrUrtNz1ux4uneLhsAKzv/0FnMbj3m6g sha512-2L0dEjIN/DAmTV5puHriEIuQU/IL3CoPm/4eyZp3bM8dnaXri6lK8u6DC5L96b+YSs9f3Le81dDRZUSYeX4QcQ==" crossorigin="anonymous">
 }
 
 #export("scripts") {
   <script src="/static/js/admin/createPost.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js" integrity="sha256-+mWd/G69S4qtgPowSELIeVAv7+FuL871WXaolgXnrwQ= sha384-222hzbb8Z8ZKe6pzP18nTSltQM3PdcAwxWKzGOKOIF+Y3bROr5n9zdQ8yTRHgQkQ sha512-bj8HE1pKwchoYNizhD57Vl6B9ExS25Hw21WxoQEzGapNNjLZ0+kgRMEn9KSCD+igbE9+/dJO7x6ZhLrdaQ5P3g==" crossorigin="anonymous"></script>
 }
 
 #export("body") {

--- a/Resources/Views/blog/admin/createPost.leaf
+++ b/Resources/Views/blog/admin/createPost.leaf
@@ -65,13 +65,13 @@
             <div class="form-group" id="create-post-tags-group">
                 <label class="form-control-label" for="inputTags">Tags</label>
                 <select class="form-control" id="inputTags" name="inputTags" placeholder="Tags" multiple="multiple">
-                  <option selected="selected">orange</option>
+                  <!-- <option selected="selected">orange</option>
                   <option>white</option>
-                  <option selected="selected">purple</option>
+                  <option selected="selected">purple</option> -->
                 </select>
                 <!-- <input type="text" class="form-control" id="inputTags" name="inputTags" placeholder="Tags" value="#(tagsSupplied)"> -->
                 <small id="tagHelpBlock" class="form-text text-muted">
-                    Tags can be added to your posts as space-separated words.
+                    Tags can be added to your posts as comma-separated entries.
                 </small>
             </div>
 

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -12,7 +12,7 @@ drop.database = database
 let memory = MemorySessions()
 let sessions = SessionsMiddleware(sessions: memory)
 drop.middleware.append(sessions)
-let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' 'unsafe-eval' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/ https://cdnjs.cloudflare.com/ajax/libs/select2/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
+let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' 'unsafe-eval' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/ https://cdnjs.cloudflare.com/ajax/libs/select2/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self';"))// upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
 drop.middleware.append(securityHeaders)
 
 try drop.addProvider(SteamPress.Provider.self)

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -12,7 +12,7 @@ drop.database = database
 let memory = MemorySessions()
 let sessions = SessionsMiddleware(sessions: memory)
 drop.middleware.append(sessions)
-let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
+let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' 'unsafe-eval' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/ https://cdnjs.cloudflare.com/ajax/libs/select2/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
 drop.middleware.append(securityHeaders)
 
 try drop.addProvider(SteamPress.Provider.self)

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -12,7 +12,7 @@ drop.database = database
 let memory = MemorySessions()
 let sessions = SessionsMiddleware(sessions: memory)
 drop.middleware.append(sessions)
-let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' 'unsafe-eval' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/ https://cdnjs.cloudflare.com/ajax/libs/select2/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self';"))// upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
+let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration(value: "default-src 'none'; script-src 'self' 'unsafe-eval' https://ajax.googleapis.com/ https://cdnjs.cloudflare.com/ https://maxcdn.bootstrapcdn.com/ https://steampress.disqus.com/ https://a.disquscdn.com/; style-src 'self' https://maxcdn.bootstrapcdn.com/ https://a.disquscdn.com/ https://cdnjs.cloudflare.com/ajax/libs/select2/; img-src 'self' data: https://referrer.disqus.com/ https://a.disquscdn.com/; connect-src 'self' https://links.services.disqus.com/; child-src https://disqus.com/; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'self'; require-sri-for script style;"))
 drop.middleware.append(securityHeaders)
 
 try drop.addProvider(SteamPress.Provider.self)


### PR DESCRIPTION
Adds Select2 to the create post page for better tagging support. Requires SteamPress to have an API endpoint for tags and for it to accept `select` results for tags instead of a single string